### PR TITLE
Added item_cash

### DIFF
--- a/csgo_extended.fgd
+++ b/csgo_extended.fgd
@@ -8436,7 +8436,7 @@
   output OnPlayerTouch(void)
   output OnIgnite(void)
 ]
-@PointClass base(Weapon) Studio("models/props_survival/cash/prop_cash_stack.mdl") = item_cash : "Cash pickup ($50)" []
+@PointClass base(Targetname, Parentname, Angles) Studio("models/props_survival/cash/prop_cash_stack.mdl") = item_cash : "Cash pickup ($50)" []
 
 //-------------------------------------------------------------------------
 // Spawnable grenades for the training map

--- a/csgo_extended.fgd
+++ b/csgo_extended.fgd
@@ -8436,6 +8436,7 @@
   output OnPlayerTouch(void)
   output OnIgnite(void)
 ]
+@PointClass base(Weapon) Studio("models/props_survival/cash/prop_cash_stack.mdl") = item_cash : "Cash pickup" []
 
 //-------------------------------------------------------------------------
 // Spawnable grenades for the training map

--- a/csgo_extended.fgd
+++ b/csgo_extended.fgd
@@ -8436,7 +8436,7 @@
   output OnPlayerTouch(void)
   output OnIgnite(void)
 ]
-@PointClass base(Weapon) Studio("models/props_survival/cash/prop_cash_stack.mdl") = item_cash : "Cash pickup" []
+@PointClass base(Weapon) Studio("models/props_survival/cash/prop_cash_stack.mdl") = item_cash : "Cash pickup ($50)" []
 
 //-------------------------------------------------------------------------
 // Spawnable grenades for the training map


### PR DESCRIPTION
Added item_cash so that it can be placed in Hammer.

"item_cash is a point entity available in Counter-Strike: Global Offensive. It's one of many new entities added with the Danger Zone update.

Creates a stack of banknotes that give $50."